### PR TITLE
Export methods and types so it's easier to customize output

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,10 @@
-import { RecordType } from "./model";
-export { RecordType } from "./model";
+import { EnumType, Field, RecordType, Type } from "./model";
+export { Type, Field, isRecordType, isArrayType, isEnumType, isMapType, RecordType, EnumType, isOptional } from "./model";
 /** Converts an Avro record type to a TypeScript file */
 export declare function avroToTypeScript(recordType: RecordType): string;
+/** Convert an Avro Record type. Return the name, but add the definition to the file */
+export declare function convertRecord(recordType: RecordType, fileBuffer: string[]): string;
+/** Convert an Avro Enum type. Return the name, but add the definition to the file */
+export declare function convertEnum(enumType: EnumType, fileBuffer: string[]): string;
+export declare function convertType(type: Type, buffer: string[]): string;
+export declare function convertFieldDec(field: Field, buffer: string[]): string;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var model_1 = require("./model");
+var model_2 = require("./model");
+exports.isRecordType = model_2.isRecordType;
+exports.isArrayType = model_2.isArrayType;
+exports.isEnumType = model_2.isEnumType;
+exports.isMapType = model_2.isMapType;
+exports.isOptional = model_2.isOptional;
 /** Convert a primitive type from avro to TypeScript */
 function convertPrimitive(avroType) {
     switch (avroType) {
@@ -37,12 +43,14 @@ function convertRecord(recordType, fileBuffer) {
     fileBuffer.push(buffer);
     return recordType.name;
 }
+exports.convertRecord = convertRecord;
 /** Convert an Avro Enum type. Return the name, but add the definition to the file */
 function convertEnum(enumType, fileBuffer) {
     var enumDef = "export enum " + enumType.name + " { " + enumType.symbols.join(", ") + " };\n";
     fileBuffer.push(enumDef);
     return enumType.name;
 }
+exports.convertEnum = convertEnum;
 function convertType(type, buffer) {
     // if it's just a name, then use that
     if (typeof type === "string") {
@@ -74,7 +82,9 @@ function convertType(type, buffer) {
         return "UNKNOWN";
     }
 }
+exports.convertType = convertType;
 function convertFieldDec(field, buffer) {
     // Union Type
     return "\t" + field.name + (model_1.isOptional(field.type) ? "?" : "") + ": " + convertType(field.type, buffer) + ";";
 }
+exports.convertFieldDec = convertFieldDec;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,5 +1,5 @@
-/**** Contains the Interfaces and Type Guards for Avro schema */
 "use strict";
+/**** Contains the Interfaces and Type Guards for Avro schema */
 Object.defineProperty(exports, "__esModule", { value: true });
 function isRecordType(type) {
     return type.type === "record";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-import {
+import {EnumType, Field, isArrayType, isEnumType, isMapType, isOptional, isRecordType, RecordType, Type} from "./model";
+
+export {
 	Type,
 	Field,
 	isRecordType,
@@ -9,7 +11,7 @@ import {
 	EnumType,
 	isOptional
 } from "./model";
-export { RecordType } from "./model";
+
 /** Convert a primitive type from avro to TypeScript */
 function convertPrimitive(avroType: string): string {
 	switch (avroType) {
@@ -37,7 +39,7 @@ export function avroToTypeScript(recordType: RecordType): string {
 }
 
 /** Convert an Avro Record type. Return the name, but add the definition to the file */
-function convertRecord(recordType: RecordType, fileBuffer: string[]): string {
+export function convertRecord(recordType: RecordType, fileBuffer: string[]): string {
 	let buffer = `export interface ${recordType.name} {\n`;
 	for (let field of recordType.fields) {
 		buffer += convertFieldDec(field, fileBuffer) + "\n";
@@ -48,13 +50,13 @@ function convertRecord(recordType: RecordType, fileBuffer: string[]): string {
 }
 
 /** Convert an Avro Enum type. Return the name, but add the definition to the file */
-function convertEnum(enumType: EnumType, fileBuffer: string[]): string {
+export function convertEnum(enumType: EnumType, fileBuffer: string[]): string {
 	const enumDef = `export enum ${enumType.name} { ${enumType.symbols.join(", ")} };\n`;
 	fileBuffer.push(enumDef);
 	return enumType.name;
 }
 
-function convertType(type: Type, buffer: string[]): string {
+export function convertType(type: Type, buffer: string[]): string {
 	// if it's just a name, then use that
 	if (typeof type === "string") {
 		return convertPrimitive(type) || type;
@@ -80,7 +82,7 @@ function convertType(type: Type, buffer: string[]): string {
 	}
 }
 
-function convertFieldDec(field: Field, buffer: string[]): string {
+export function convertFieldDec(field: Field, buffer: string[]): string {
 	// Union Type
 	return `\t${field.name}${isOptional(field.type) ? "?" : ""}: ${convertType(field.type, buffer)};`;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var fs = require("fs");
-var _1 = require("../lib/");
+var lib_1 = require("../lib/");
 var schemaText = fs.readFileSync(__dirname + "/example.avsc", "UTF8");
 var schema = JSON.parse(schemaText);
-console.log(_1.avroToTypeScript(schema));
+console.log(lib_1.avroToTypeScript(schema));


### PR DESCRIPTION
First of all, this is a great library that saved us a lot of time so thanks for sharing!

We wanted to change the output classes a bit, but it turned out that that would require to rewrite the whole index.ts since only main function `avroToTypescript` is exported. I wanted to declare my own `convertRecord` method but it turned out I would have to redeclare all the methods from index.ts because they are not exported so I could not use them in my own custom `convertRecord`. This is a small, non-breaking change that would help us a lot so please let me know what you think.

Have a great day!