### PR TITLE
Support logicalTypes type overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,57 @@ const schema = JSON.parse(schemaText) as RecordType;
 console.log(avroToTypeScript(schema as RecordType));
 ```
 
+## Override logicalTypes
+
+Tools like [avsc](https://github.com/mtth/avsc) allow you to [override the serialization/deserialization of LogicalTypes](https://github.com/mtth/avsc/wiki/Advanced-usage#logical-types),
+ say from numbers to native JS Date objects, in this case we want to generate the typescript type as 'Date', not 'number'.
+ Therefore, you can pass in a map 'logicalTypes' to the options to override the outputted TS type for the schema logicalType.
+ 
+For example:
+
+```typescript
+const schema: Schema = {
+    type: "record",
+    name: "logicalOverrides",
+    fields: [
+        {
+            name: "eventDate",
+            type: {
+                type: "int",
+                logicalType: "date",
+            },
+        },
+        {
+            name: "startTime",
+            type: {
+                type: "int",
+                logicalType: "timestamp-millis",
+            },
+        },
+        {
+            name: "displayTime",
+            type: {
+                type: "string",
+                logicalType: "iso-datetime",
+            },
+        },
+    ],
+};
+const actual = avroToTypeScript(schema, {
+logicalTypes: {
+    date: 'Date',
+    'timestamp-millis': 'Date',
+}
+});
+
+// this will output
+export interface logicalOverrides {
+    eventDate: Date;
+    startTime: Date;
+    displayTime: string;
+}
+```
+
 ## Features
 
 Most Avro features are supported, including:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avro-typescript",
-  "version": "0.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export function convertPrimitive(avroType: string): string {
         case "bytes":
             return "Buffer";
         case "null":
-            return "null | undefined";
+            return "null";
         case "boolean":
             return "boolean";
         default:
@@ -66,7 +66,7 @@ export function convertRecord(recordType: RecordType, fileBuffer: string[]): str
 
 /** Convert an Avro Enum type. Return the name, but add the definition to the file */
 export function convertEnum(enumType: EnumType, fileBuffer: string[]): string {
-    const enumDef = `export enum ${enumType.name} { ${enumType.symbols.join(", ")} };\n`;
+    const enumDef = `export enum ${enumType.name} { ${enumType.symbols.map(sym => `${sym} = '${sym}'`).join(", ")} };\n`;
     fileBuffer.push(enumDef);
     return enumType.name;
 }
@@ -101,5 +101,5 @@ export function convertType(type: Type, buffer: string[]): string {
 
 export function convertFieldDec(field: Field, buffer: string[]): string {
     // Union Type
-    return `\t${field.name}${isOptional(field.type) ? "?" : ""}: ${convertType(field.type, buffer)};`;
+    return `\t${field.name}: ${convertType(field.type, buffer)};`;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,9 @@
 /**** Contains the Interfaces and Type Guards for Avro schema */
 
 export type Schema = RecordType | EnumType;
+export interface ConversionOptions {
+    logicalTypes?: { [type: string]: string };
+}
 
 export type Type = NameOrType | NameOrType[];
 export type NameOrType = TypeNames | RecordType | ArrayType | NamedType | LogicalType;

--- a/test/__snapshots__/avtsc.test.ts.snap
+++ b/test/__snapshots__/avtsc.test.ts.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`avroToTypeScript it should generate an interface 1`] = `
-"export enum numberEnumType { ONE, TWO };
+"export enum numberEnumType { ONE = 'ONE', TWO = 'TWO' };
 
 export interface AllocsType {
-	allocAccount?: null | undefined | string;
-	noNestedPartyIDs?: null | undefined | number;
-	allocQty?: null | undefined | number;
+	allocAccount: null | string;
+	noNestedPartyIDs: null | number;
+	allocQty: null | number;
 }
 
 export interface ExampleType {
-	unionEnum?: null | undefined | string | numberEnumType;
+	unionEnum: null | string | numberEnumType;
 	mandatoryString: string;
-	adouble?: null | undefined | number;
-	astring?: null | undefined | string;
-	amap?: null | undefined | string | { [index:string]:numberEnumType };
-	recordArray?: null | undefined | AllocsType[];
-	processCode?: null | undefined | string;
-	named?: null | undefined | AllocsType;
+	adouble: null | number;
+	astring: null | string;
+	amap: null | string | { [index:string]:numberEnumType };
+	recordArray: null | AllocsType[];
+	processCode: null | string;
+	named: null | AllocsType;
 }
 "
 `;
 
 exports[`enumToTypesScript it should generate an enum 1`] = `
-"export enum CompanySize { SMALL, MEDIUM, LARGE };
+"export enum CompanySize { SMALL = 'SMALL', MEDIUM = 'MEDIUM', LARGE = 'LARGE' };
 "
 `;

--- a/test/__snapshots__/avtsc.test.ts.snap
+++ b/test/__snapshots__/avtsc.test.ts.snap
@@ -22,6 +22,15 @@ export interface ExampleType {
 "
 `;
 
+exports[`avroToTypeScript it should support overriding logical types 1`] = `
+"export interface logicalOverrides {
+	eventDate: Date;
+	startTime: Date;
+	displayTime: string;
+}
+"
+`;
+
 exports[`enumToTypesScript it should generate an enum 1`] = `
 "export enum CompanySize { SMALL, MEDIUM, LARGE };
 "

--- a/test/avtsc.test.ts
+++ b/test/avtsc.test.ts
@@ -25,6 +25,46 @@ describe("avroToTypeScript", () => {
         };
         expect(avroToTypeScript(schema)).not.toEqual(expect.stringContaining("UNKNOWN"));
     });
+
+    test("it should support overriding logical types", () => {
+        const schema: Schema = {
+            type: "record",
+            name: "logicalOverrides",
+            fields: [
+                {
+                    name: "eventDate",
+                    type: {
+                        type: "int",
+                        logicalType: "date",
+                    },
+                },
+                {
+                    name: "startTime",
+                    type: {
+                        type: "int",
+                        logicalType: "timestamp-millis",
+                    },
+                },
+                {
+                    name: "displayTime",
+                    type: {
+                        type: "string",
+                        logicalType: "iso-datetime",
+                    },
+                },
+            ],
+        };
+        const actual = avroToTypeScript(schema, {
+            logicalTypes: {
+                date: 'Date',
+                'timestamp-millis': 'Date',
+            }
+        });
+        expect(actual).toMatchSnapshot();
+        expect(actual).not.toEqual(expect.stringContaining("eventDate: number"));
+        expect(actual).not.toEqual(expect.stringContaining("startTime: number"));
+        expect(actual).toEqual(expect.stringContaining("displayTime: string"));
+    });
 });
 
 describe("enumToTypesScript", () => {


### PR DESCRIPTION
Related to my PR #13  we are using avsc npm module for our avro serialization/deserialization in our project. I am using the logicalTypes options in avro to transparently serialize/deserialize logical Dates and Timestamps to JS Dates (rather than numbers). Therefore, when generating Typescript defs I would like an option to have the logicalTypes overridden to match.