### PR TITLE
Enum and Null types incorrect (for avsc)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avro-typescript",
-  "version": "0.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export function convertPrimitive(avroType: string): string {
         case "bytes":
             return "Buffer";
         case "null":
-            return "null | undefined";
+            return "null";
         case "boolean":
             return "boolean";
         default:
@@ -66,7 +66,7 @@ export function convertRecord(recordType: RecordType, fileBuffer: string[]): str
 
 /** Convert an Avro Enum type. Return the name, but add the definition to the file */
 export function convertEnum(enumType: EnumType, fileBuffer: string[]): string {
-    const enumDef = `export enum ${enumType.name} { ${enumType.symbols.join(", ")} };\n`;
+    const enumDef = `export enum ${enumType.name} { ${enumType.symbols.map(sym => `${sym} = '${sym}'`).join(", ")} };\n`;
     fileBuffer.push(enumDef);
     return enumType.name;
 }
@@ -101,5 +101,5 @@ export function convertType(type: Type, buffer: string[]): string {
 
 export function convertFieldDec(field: Field, buffer: string[]): string {
     // Union Type
-    return `\t${field.name}${isOptional(field.type) ? "?" : ""}: ${convertType(field.type, buffer)};`;
+    return `\t${field.name}: ${convertType(field.type, buffer)};`;
 }

--- a/test/__snapshots__/avtsc.test.ts.snap
+++ b/test/__snapshots__/avtsc.test.ts.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`avroToTypeScript it should generate an interface 1`] = `
-"export enum numberEnumType { ONE, TWO };
+"export enum numberEnumType { ONE = 'ONE', TWO = 'TWO' };
 
 export interface AllocsType {
-	allocAccount?: null | undefined | string;
-	noNestedPartyIDs?: null | undefined | number;
-	allocQty?: null | undefined | number;
+	allocAccount: null | string;
+	noNestedPartyIDs: null | number;
+	allocQty: null | number;
 }
 
 export interface ExampleType {
-	unionEnum?: null | undefined | string | numberEnumType;
+	unionEnum: null | string | numberEnumType;
 	mandatoryString: string;
-	adouble?: null | undefined | number;
-	astring?: null | undefined | string;
-	amap?: null | undefined | string | { [index:string]:numberEnumType };
-	recordArray?: null | undefined | AllocsType[];
-	processCode?: null | undefined | string;
-	named?: null | undefined | AllocsType;
+	adouble: null | number;
+	astring: null | string;
+	amap: null | string | { [index:string]:numberEnumType };
+	recordArray: null | AllocsType[];
+	processCode: null | string;
+	named: null | AllocsType;
 }
 "
 `;
 
 exports[`enumToTypesScript it should generate an enum 1`] = `
-"export enum CompanySize { SMALL, MEDIUM, LARGE };
+"export enum CompanySize { SMALL = 'SMALL', MEDIUM = 'MEDIUM', LARGE = 'LARGE' };
 "
 `;


### PR DESCRIPTION
### Proposed Change

Generate enums as String Enums and convert nulls as explicit nulls.

| type | Before  | After |
| --- | ------------- | ------------- |
| Enum | `export enum CompanySize { SMALL, MEDIUM, LARGE }`  | `export enum CompanySize { SMALL = 'SMALL', MEDIUM = 'MEDIUM', LARGE = 'LARGE' }`  |
| null | `allocAccount?: null \| undefined \| string;`  | `allocAccount: null \| string;` |


### Background/Use case - pre-compile types

I notice from other issue comments that you intend to use this more as a **runtime** tool for something called Monaco (I am not familiar with what this is?). My use-case is more similar to #1 - a compilation step. I intend to compile from avro schema to typescript definitions so that our app can benefit from static type checking when we're creating avro messages, for example:

```ts
// User.avsc
{
  "type": "record",
  "name": "User",
  "fields": [
    {
      "name": "name",
      "type": ["null", "string"]
    },
   {
      "name": "sex",
      "type": {
        "name": "Sex",
        "type": "enum",
        "symbols": [
          "male",
          "female"
        ]
      }
    }
  ]
}

// avro-build-script.ts
const schemaText = readFileSync('./User.avsc'), 'UTF8');
const schema = JSON.parse(schemaText) as RecordType;
const types = avroToTypeScript(schema);
writeFileSync('User.ts'), types);

// this creates User.ts
export enum Sex {
  male,
  female,
}

export interface User {
  name?: null | undefined | string;
  sex: Sex;
}

// I can then use this in my code and benefit from static type checking
// producer.ts
import * as avro from 'avsc';
import { User, Sex } from './User.ts';

const userSchema = readFileSync('./User.avsc'), 'utf-8');
const Type = avro.Type.forSchema(JSON.parse(userSchema));

 // Typescript compiler complains here
const badUserMessage: User = {
  name: false,
  sex: 'm',
};

// Typescript compiler is happy
const goodUserMessage: User = {
  name: 'Jerome', 
  sex: Sex.M,
};
```

Note: I am using [avsc](https://github.com/mtth/avsc) here in order to encode/decode messages

### Issue

The problem I am seeing is that when using avsc these definitions are not actually accurate for encoding the message (avsc seems to be the de-facto tool for avro in js but I haven't tried any other serializers).

avsc expects the enums to strings represent the enum symbol, rather than the numbers given by standard/numeric enum in TS.

avsc also expects that nulls are explicit (I guess undefined as a concept doesn't exist in avro). Therefore the typedef that `name?: null | undefined | string` doesn't actually satisfy constrains in terms of encoding.

Examples of issues before this change:

```ts
// bad enum, value is 1
const message: User = {
  name: 'Sarah',
  sex: Sex.F
}
// > Error: invalid ["null",{"name":"Sex","type":"enum","symbols":["male","female"]}]: 0

// explicit undefined
const message: User = {
  name: undefined,
  sex: 'male'
}
// > Error: invalid ["null","string"]: undefined

// implicit undefined
const message: User = {
  sex: 'male'
}
// > Error: invalid ["null","string"]: undefined
```